### PR TITLE
Disable xml formatting

### DIFF
--- a/source/fb2save.cpp
+++ b/source/fb2save.cpp
@@ -23,7 +23,7 @@
 #include <QWebPage>
 #include <QtDebug>
 
-#define XMLAutoFormatting
+//#define XMLAutoFormatting
 //#define ImgTypePrint
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
XML formatting does not break up the binaries base64 into chunks, which slows down external editors, this commit just disables formatting.